### PR TITLE
Fixed null popup access when clicking on Region after new game

### DIFF
--- a/TravelOptions/Scripts/TravelOptionsMapWindow.cs
+++ b/TravelOptions/Scripts/TravelOptionsMapWindow.cs
@@ -513,7 +513,7 @@ namespace TravelOptions
                 base.ClickHandler(sender, position);
             }
             // Set scale factors into popup, except when teleport travelling
-            if (!teleportationTravel)
+            if (popUp != null && !teleportationTravel)
                 ((TravelOptionsPopUp)popUp).SetScaleFactors(TravelOptionsMod.Instance.FastTravelCostScaleFactor, TravelOptionsMod.Instance.ShipTravelCostScaleFactor);
         }
 


### PR DESCRIPTION
If you start a new game and never save/reload, once you open the Travel map and click on a region, you get a null reference access.

![image](https://github.com/ajrb/dfunity-mods/assets/5789925/6de88bb1-e0e5-43aa-9829-d7e373de2768)

This is because the popup in DaggerfallTravelWindow is only set when loading a save, or when starting a travel. Clicking a region on a new save does neither.

Just added a null check there